### PR TITLE
new call to get chain tip

### DIFF
--- a/src/electrumx_client.rs
+++ b/src/electrumx_client.rs
@@ -10,9 +10,9 @@ use interface::Electrumx;
 use raw_response::{GetBlockHeaderRawResponse, GetBlockHeadersRawResponse, EstimateFeeRawResponse,
    RelayFeeRawResponse, GetBalanceRawResponse, GetHistoryRawResponse,
    GetListUnspentRawResponse, BroadcastTransactionRawResponse, GetTransactionRawResponse,
-   GetTransactionConfStatusRawResponse};
+   GetTransactionConfStatusRawResponse, GetTipRawResponse};
 use response::{GetBlockHeadersResponse, GetBalanceResponse, GetHistoryResponse, GetListUnspentResponse,
-    GetTransactionConfStatus};
+    GetTransactionConfStatus, GetTipResponse};
 use tools;
 
 pub struct ElectrumxClient<A: ToSocketAddrs> {
@@ -29,6 +29,14 @@ impl<A: ToSocketAddrs + Clone> Electrumx for ElectrumxClient<A> {
         let resp: GetBlockHeaderRawResponse = serde_json::from_slice(&raw)?;
         Ok(resp.result)
     }
+
+    fn get_tip_header(&mut self) -> Result<GetTipResponse, Box<dyn Error>> {
+        let req = Request::new(0, "blockchain.headers.subscribe", Vec::new());
+        self.call(req)?;
+        let raw = self.recv()?;
+        let resp: GetTipRawResponse = serde_json::from_slice(&raw)?;
+        Ok(resp.result)
+    }    
 
     fn get_block_headers(&mut self, start_height: usize, count: usize) -> Result<GetBlockHeadersResponse, Box<dyn Error>> {
         let params = vec![

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use response::{GetBlockHeadersResponse, GetBalanceResponse, GetHistoryResponse, GetListUnspentResponse, GetTransactionConfStatus};
+use response::{GetBlockHeadersResponse, GetBalanceResponse, GetHistoryResponse, GetListUnspentResponse, GetTransactionConfStatus, GetTipResponse};
 
 pub trait Electrumx {
     // Return the block header at the given height.
@@ -52,4 +52,5 @@ pub trait Electrumx {
     fn get_merkle_transaction(&mut self, tx_hash: String, height: usize) -> Result<Vec<u8>, Box<dyn Error>>;
     fn transaction_id_from_pos(&mut self, height: usize, tx_pos: usize, merkle: bool) -> Result<Vec<u8>, Box<dyn Error>>;
     fn get_fee_histogram_mempool(&mut self) -> Result<Vec<u8>, Box<dyn Error>>;
+    fn get_tip_header(&mut self) -> Result<GetTipResponse, Box<dyn Error>>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,8 @@ fn main() {
         .subcommand(SubCommand::with_name("relayfee")
             .about("Return the minimum fee a low-priority transaction must pay in order to be \
             accepted to the daemon’s memory pool."))
+        .subcommand(SubCommand::with_name("gettipheader")
+            .about("Return the blockchain tip header and current block height."))
         .subcommand(SubCommand::with_name("toscripthash")
             .arg(Arg::with_name("addr")
                 .long("addr")
@@ -194,6 +196,11 @@ fn main() {
         let fee = client.relay_fee().unwrap();
         println!("{}", fee);
     }
+
+    if let Some(_matches) = matches.subcommand_matches("gettipheader") {
+        let resp = client.get_tip_header().unwrap();
+        println!("{:?}", resp);
+    }    
 
     if let Some(matches) = matches.subcommand_matches("getbalance") {
         let addr = matches.value_of("addr").unwrap();

--- a/src/raw_response.rs
+++ b/src/raw_response.rs
@@ -1,10 +1,17 @@
-use response::{GetTransactionConfStatus, GetBlockHeadersResponse, GetBalanceResponse, GetHistoryResponse, GetListUnspentResponse};
+use response::{GetTransactionConfStatus, GetTipResponse, GetBlockHeadersResponse, GetBalanceResponse, GetHistoryResponse, GetListUnspentResponse};
 
 #[derive(Debug, Deserialize)]
 pub struct GetBlockHeaderRawResponse {
     id:      usize,
     jsonrpc: String,
     pub result:  String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GetTipRawResponse {
+    id:      usize,
+    jsonrpc: String,
+    pub result:  GetTipResponse,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,6 +6,12 @@ pub struct GetBlockHeadersResponse {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct GetTipResponse {
+    pub height: usize,
+    pub hex:   String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct GetBalanceResponse {
     pub confirmed:   u64,
     pub unconfirmed: u64,


### PR DESCRIPTION
Addition of a call to get the current block height from an electrum server (needed for setting the locktimes). 